### PR TITLE
RFC: Create a model for Linksys SWR switches

### DIFF
--- a/lib/oxidized/model/LinksysSRW.rb
+++ b/lib/oxidized/model/LinksysSRW.rb
@@ -1,0 +1,67 @@
+class LinksysSRW < Oxidized::Model
+
+  comment '! '
+
+  prompt /^([\r\w.@-]+[#>]\s?)$/
+
+  # Graphical login screen
+  # Just login to get to Main Menu
+  expect /Login Screen/ do |data, re|
+    Oxidized.logger.send(:debug, "#{self.class.name}: Login Screen")
+    # This is to ensure the whole thing have rendered before we send stuff
+    sleep 0.2
+    send 0x18.chr # CAN Cancel
+    send @node.auth[:username]
+    send "\t"
+    send @node.auth[:password]
+    send "\r"
+  end
+
+  # Main menu, escape into Pre-cli-shell
+  expect /Switch Main Menu/ do |data, re|
+    Oxidized.logger.send(:debug, "#{self.class.name}: Switch menu")
+    send 0x1a.chr # SUB Substitite ^z
+  end
+
+  # Pre-cli-shell, start lcli which is ios-ish
+  expect />/ do |data, re|
+    Oxidized.logger.send(:debug, "#{self.class.name}: >")
+    send "lcli\r"
+  end
+
+  cmd :all do |cfg|
+    # Remove \r from first response row
+    cfg.gsub! /^\r/, ''
+    cfg.cut_tail + "\n"
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(enable (password|secret)( level \d+)? \d) .+/, '\\1 <secret hidden>'
+  end
+
+  cmd 'show startup-config' do |cfg|
+    # Repair some linewraps which terminal datadump doesn't take care of
+    # and there's no terminal width either.
+    cfg.gsub! /(lldpPortConfigT)\n(LVsTxEnable)/, '\\1\\2'
+    # And comment out the echo of the command
+    "#{comment cfg.lines.first}#{cfg.cut_head}"
+  end
+
+  cmd 'show version' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show system' do |cfg|
+    cfg.gsub! /(System Up Time \(days,hour:min:sec\):\s+).*/, '\\1 <uptime removed>'
+    comment cfg
+  end
+
+  cfg :telnet do
+    # Pre-cli-shell just expects a username, who its going to log in.
+    username /^User Name:/
+    post_login 'terminal datadump'
+    pre_logout 'exit'
+    pre_logout 'logout'
+  end
+end


### PR DESCRIPTION
This creates a model for Linksys SWR switches by sneaking out form the menu mode and starting the lcli tool to be able to dump the config.

Due to the fact that we're navigating and escaping from a curses mode I'm not using the regular username/password entry procedures, but I'm rather chaining a bunch of expect to do the login and start the terminal mode.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This is a RFC for Linksys SWR support. I'm probably abusing a lot of code here, and I should write both documentation and some explaining about the model but I'm throwing this out there for some early feedback.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
This resolves #875